### PR TITLE
snap: use apt dep instead of snap

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,11 +53,8 @@ jobs:
         
         # workaround for GithubActionsCI+snapcraft, see https://forum.snapcraft.io/t/permissions-problem-using-snapcraft-in-azure-pipelines/13258/14
         sudo chown root:root /
+
         snapcraft --version
-        
-        # use multipass provider as lxd doesn't work for some reason
-        sudo snap install multipass
-        sudo snap set snapcraft provider=multipass
         
     - name: Build
       run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -60,7 +60,11 @@ jobs:
         sudo snap set snapcraft provider=multipass
         
     - name: Build
-      run: dotnet build --configuration Release
+      run: |
+        dotnet build --configuration Release
+        mkdir staging
+        cp -rfvp src/PackWallet/bin/Release/net7.0/* staging/
+        cp src/PackWallet/launch.sh staging/
 
     - name: Generate snap package
       run: sudo snapcraft --destructive-mode --verbosity=verbose || sudo bash -c 'cat /root/.local/state/snapcraft/log/*.log'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -64,7 +64,7 @@ jobs:
         cp src/PackWallet/launch.sh staging/
 
     - name: Generate snap package
-      run: sudo snapcraft --destructive-mode --verbosity=verbose || sudo bash -c 'cat /root/.local/state/snapcraft/log/*.log'
+      run: sudo snapcraft --destructive-mode --verbosity=verbose || (sudo bash -c 'cat /root/.local/state/snapcraft/log/*.log' && exit 1)
 
     - uses: actions/upload-artifact@v3
       name: Upload snap package as artifact

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,14 +10,13 @@ confinement: devmode # use 'strict' once you have the right plugs and slots
 
 parts:
   dotnet-fsharp-helloworld:
-    plugin: dotnet
-    source: .
+    plugin: dump
+    source: ./staging
     build-packages:
       - dotnet-sdk-7.0
-    stage-snaps:
-      - dotnet-runtime-70
+    stage-packages:
+      - dotnet-runtime-7.0
 
 apps:
   dotnet-fsharp-helloworld:
     command: launch.sh
-

--- a/src/PackWallet/launch.sh
+++ b/src/PackWallet/launch.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-$SNAP/dotnet $SNAP/PackWallet.dll "$@"
+dotnet $SNAP/PackWallet.dll "$@"


### PR DESCRIPTION
As a workaround to this issue:
https://github.com/canonical/dotnet-snap/issues/14