### PR TITLE
Use stage-snaps instead of stage-packages again

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,7 +49,7 @@ jobs:
         sudo apt install -y snapd
         snap version
 
-        sudo snap install --classic snapcraft
+        sudo snap install --classic snapcraft --channel=7.x/stable
         
         # workaround for GithubActionsCI+snapcraft, see https://forum.snapcraft.io/t/permissions-problem-using-snapcraft-in-azure-pipelines/13258/14
         sudo chown root:root /

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -57,11 +57,7 @@ jobs:
         snapcraft --version
         
     - name: Build
-      run: |
-        dotnet build --configuration Release
-        mkdir staging
-        cp -rfvp src/PackWallet/bin/Release/net7.0/* staging/
-        cp src/PackWallet/launch.sh staging/
+      run: dotnet build --configuration Release
 
     - name: Generate snap package
       run: sudo snapcraft --destructive-mode --verbosity=verbose || (sudo bash -c 'cat /root/.local/state/snapcraft/log/*.log' && exit 1)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,7 +15,7 @@ parts:
     build-packages:
       - dotnet-sdk-7.0
     stage-snaps:
-      - dotnet-runtime-70
+      - dotnet-runtime-70/latest/candidate
 
 apps:
   dotnet-fsharp-helloworld:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,13 +10,14 @@ confinement: devmode # use 'strict' once you have the right plugs and slots
 
 parts:
   dotnet-fsharp-helloworld:
-    plugin: dump
-    source: ./staging
+    plugin: dotnet
+    source: .
     build-packages:
       - dotnet-sdk-7.0
-    stage-packages:
-      - dotnet-runtime-7.0
+    stage-snaps:
+      - dotnet-runtime-70
 
 apps:
   dotnet-fsharp-helloworld:
     command: launch.sh
+

--- a/src/PackWallet/launch.sh
+++ b/src/PackWallet/launch.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-dotnet $SNAP/PackWallet.dll "$@"
+$SNAP/dotnet $SNAP/PackWallet.dll "$@"


### PR DESCRIPTION
Revert commit a8fac58b45d9fedcfafc5d591b384e1a95be40fb and implement fixes that allow to use `dotnet-runtime-70` snap without getting an error.